### PR TITLE
Fix corrupt responses from invalid byte calculation in HttpClient.cs

### DIFF
--- a/WebServer/HttpClient.cs
+++ b/WebServer/HttpClient.cs
@@ -190,53 +190,11 @@ namespace JAWS
             }
             Response.Headers.Add("Server", Server.ServerName);
 
-// Commented out 14th June 2021. Fixed multi-content byte issue bug where bytes are not sent correctly causing corrupt responses
-//             byte[] Headers = Response.GetHeaderBytes();
-//             long Length = Headers.Length + Response.Content.Length;
-//             long Size = Math.Min(Length, SendBufferSize);
-//             byte[] Chunk = new byte[Size];
-
-//             long Offset = 0;
-//             while (Offset < Length)
-//             {
-//                 int CurrentChunkWidth = 0;
-//                 int RestChunkWidth = 0;
-//                 if (Offset < Headers.Length)
-//                 {
-//                     CurrentChunkWidth = (int)Math.Min(Headers.Length - Offset, Size);
-//                     Array.Copy(Headers, Offset, Chunk, 0, CurrentChunkWidth);
-//                 }
-
-//                 if (CurrentChunkWidth < Size)
-//                 {
-//                     RestChunkWidth = (int)Math.Min(Response.Content.Length - Response.Content.Position, Size - CurrentChunkWidth);
-//                     Response.Content.Read(Chunk, CurrentChunkWidth, RestChunkWidth);
-//                 }
-
-//                 int Sent = CurrentChunkWidth + RestChunkWidth;
-//                 try
-//                 {
-//                     Stream.Write(Chunk, 0, Sent);
-//                 }
-//                 catch (Exception e)
-//                 {
-//                     // The client was disconnected during this, only show as information
-//                     // since it's likely due to being closed.
-//                     Server.Log(HttpServer.LOG_TYPE.INFO, "The client has unexpectedly disconnected.", e.Message);
-//                     //if (e.Message.IndexOf("forcibly closed") > -1)
-//                     //{
-//                     //    Server.Log(HttpServer.LOG_TYPE.WARNING, "The connection was forcibly closed, are we sending bytes correctly?");
-//                     //}
-//                     return;
-//                 }
-
-//                 Offset += Sent;
-//             }
             byte[] Headers = Response.GetHeaderBytes();
             
             long Length = Headers.Length + Response.Content.Length;
             
-            int Size = (Length < BUFFER_SIZE ? (int)Length : BUFFER_SIZE);
+            int Size = (Length < SendBufferSize ? (int)Length : SendBufferSize);
             byte[] Chunk;
 
             int Offset = 0, ChunkSize = 0, Sent;

--- a/WebServer/HttpClient.cs
+++ b/WebServer/HttpClient.cs
@@ -190,52 +190,102 @@ namespace JAWS
             }
             Response.Headers.Add("Server", Server.ServerName);
 
-            byte[] Headers = Response.GetHeaderBytes();
-            long Length = Headers.Length + Response.Content.Length;
-            long Size = Math.Min(Length, SendBufferSize);
-            byte[] Chunk = new byte[Size];
+// Commented out 14th June 2021. Fixed multi-content byte issue bug where bytes are not sent correctly causing corrupt responses
+//             byte[] Headers = Response.GetHeaderBytes();
+//             long Length = Headers.Length + Response.Content.Length;
+//             long Size = Math.Min(Length, SendBufferSize);
+//             byte[] Chunk = new byte[Size];
 
-            long Offset = 0;
+//             long Offset = 0;
+//             while (Offset < Length)
+//             {
+//                 int CurrentChunkWidth = 0;
+//                 int RestChunkWidth = 0;
+//                 if (Offset < Headers.Length)
+//                 {
+//                     CurrentChunkWidth = (int)Math.Min(Headers.Length - Offset, Size);
+//                     Array.Copy(Headers, Offset, Chunk, 0, CurrentChunkWidth);
+//                 }
+
+//                 if (CurrentChunkWidth < Size)
+//                 {
+//                     RestChunkWidth = (int)Math.Min(Response.Content.Length - Response.Content.Position, Size - CurrentChunkWidth);
+//                     Response.Content.Read(Chunk, CurrentChunkWidth, RestChunkWidth);
+//                 }
+
+//                 int Sent = CurrentChunkWidth + RestChunkWidth;
+//                 try
+//                 {
+//                     Stream.Write(Chunk, 0, Sent);
+//                 }
+//                 catch (Exception e)
+//                 {
+//                     // The client was disconnected during this, only show as information
+//                     // since it's likely due to being closed.
+//                     Server.Log(HttpServer.LOG_TYPE.INFO, "The client has unexpectedly disconnected.", e.Message);
+//                     //if (e.Message.IndexOf("forcibly closed") > -1)
+//                     //{
+//                     //    Server.Log(HttpServer.LOG_TYPE.WARNING, "The connection was forcibly closed, are we sending bytes correctly?");
+//                     //}
+//                     return;
+//                 }
+
+//                 Offset += Sent;
+//             }
+            byte[] Headers = Response.GetHeaderBytes();
+            
+            long Length = Headers.Length + Response.Content.Length;
+            
+            int Size = (Length < BUFFER_SIZE ? (int)Length : BUFFER_SIZE);
+            byte[] Chunk;
+
+            int Offset = 0, ChunkSize = 0, Sent;
             while (Offset < Length)
             {
-                int CurrentChunkWidth = 0;
-                int RestChunkWidth = 0;
+
+                Chunk = new byte[Size];
+
+                ChunkSize = 0;
+
                 if (Offset < Headers.Length)
                 {
-                    CurrentChunkWidth = (int)Math.Min(Headers.Length - Offset, Size);
-                    Array.Copy(Headers, Offset, Chunk, 0, CurrentChunkWidth);
+                    ChunkSize = (int)Math.Min(Headers.Length - Offset, Size);
+                    Array.Copy(Headers, Offset, Chunk, 0, ChunkSize);
                 }
 
-                if (CurrentChunkWidth < Size)
+                if (Offset + ChunkSize >= Headers.Length)
                 {
-                    RestChunkWidth = (int)Math.Min(Response.Content.Length - Response.Content.Position, Size - CurrentChunkWidth);
-                    Response.Content.Read(Chunk, CurrentChunkWidth, RestChunkWidth);
+                    ChunkSize += Response.Content.Read(Chunk, ChunkSize, Size - ChunkSize);
                 }
 
-                int Sent = CurrentChunkWidth + RestChunkWidth;
                 try
                 {
-                    Stream.Write(Chunk, 0, Sent);
+                    if (ChunkSize < Size)
+                    {
+                        // We must resize when we're ending with less than the buffer
+                        // size as we otherwise send a bunch of zeros that we don't need
+                        byte[] Temp = Chunk;
+                        Chunk = new byte[ChunkSize];
+                        Array.Copy(Temp, Chunk, ChunkSize);
+                    }
+                    Sent = Client.Send(Chunk, 0);
                 }
-                catch (Exception e)
+                catch (Exception Ex)
                 {
-                    // The client was disconnected during this, only show as information
-                    // since it's likely due to being closed.
-                    Server.Log(HttpServer.LOG_TYPE.INFO, "The client has unexpectedly disconnected.", e.Message);
-                    //if (e.Message.IndexOf("forcibly closed") > -1)
-                    //{
-                    //    Server.Log(HttpServer.LOG_TYPE.WARNING, "The connection was forcibly closed, are we sending bytes correctly?");
-                    //}
+                    Stream.Close();
+                    //Server.Log(HttpServer.LOG_TYPE.INFO, "The client has unexpectedly disconnected.", e.Message);
+                    Server.Log(HttpServer.LOG_TYPE.INFO, $"Client connection failed to write chunk ({Offset}/{Length}): {Ex}");
                     return;
                 }
 
                 Offset += Sent;
-            }
-
-            if (!KeepAlive)
-            {
+           }
+            
+           if (!KeepAlive)
+           {
                 Close();
-            }
+                Stream.Close();
+           }
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes an issue whereby responses would sometimes be corrupt due to a confusing chunk calculation. Beforehand I think this went unseen as we were not hitting the usecases that cause corrupt resources, although I remember corrupt responses as something I had discovered before. The calculation has been simplified quite a bit, and I've indirectly tested this on another project which previously had a broken SVG and JS files which all now load perfectly.

The code in this branch has not yet been properly tested just yet, but if I do find something I will fix it in another commit before merging to master 😄